### PR TITLE
Integrate Supabase persistence and document deployment setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# URL base do seu projeto Supabase
+NEXT_PUBLIC_SUPABASE_URL=
+
+# Chave pública (anon) do Supabase para uso no cliente, se necessário
+SUPABASE_ANON_KEY=
+
+# Chave Service Role do Supabase (use apenas no servidor/Vercel)
+SUPABASE_SERVICE_ROLE_KEY=
+
+# Chave para a API do Google GenAI utilizada pelo fluxo de IA
+GOOGLE_GENAI_API_KEY=

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals"]
+}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,63 @@
-# Firebase Studio
+# EnvironPact Formulário
 
-This is a NextJS starter in Firebase Studio.
+Aplicação Next.js para gestão de formulários de sustentabilidade, com persistência no Supabase e deploy via Vercel.
 
-To get started, take a look at src/app/page.tsx.
+## Pré-requisitos
+
+- Node.js 18 ou 20
+- Uma instância do Supabase com acesso ao painel SQL
+- Conta na Vercel conectada ao seu repositório GitHub
+
+## Configuração do ambiente local
+
+1. Instale as dependências do projeto:
+
+   ```bash
+   npm install
+   ```
+
+2. Copie o arquivo `.env.example` para `.env.local` e preencha as variáveis:
+
+   ```bash
+   cp .env.example .env.local
+   ```
+
+   - `NEXT_PUBLIC_SUPABASE_URL`: URL base do projeto Supabase
+   - `SUPABASE_ANON_KEY`: chave pública (opcional no momento, mas útil para futuras interações no cliente)
+   - `SUPABASE_SERVICE_ROLE_KEY`: chave Service Role (utilizada apenas no servidor / server actions)
+   - `GOOGLE_GENAI_API_KEY`: chave da API Google GenAI usada pelo fluxo de notificação por IA
+
+3. Crie as tabelas necessárias no Supabase executando o script [`docs/supabase-schema.sql`](docs/supabase-schema.sql) no editor SQL do painel.
+
+4. Com tudo configurado, rode a aplicação:
+
+   ```bash
+   npm run dev
+   ```
+
+## Arquitetura resumida
+
+- **Next.js 15 (App Router)** com componentes cliente e server actions.
+- **Supabase** usado como banco principal. As server actions fazem chamadas ao PostgREST com a chave Service Role para criar projetos, destinatários e submissões.
+- **Genkit / Google GenAI** gera a mensagem de conclusão quando todos os destinatários respondem.
+
+A pasta `src/lib/supabase` contém o cliente mínimo utilizado pelas server actions.
+
+## Scripts úteis
+
+| Comando           | Descrição                             |
+|-------------------|---------------------------------------|
+| `npm run dev`     | Inicia o servidor de desenvolvimento   |
+| `npm run build`   | Gera o build de produção do Next.js    |
+| `npm run start`   | Inicia o servidor em modo produção     |
+| `npm run lint`    | Executa o lint padrão do Next.js       |
+| `npm run typecheck` | Verifica os tipos com TypeScript    |
+
+## Deploy na Vercel
+
+1. Faça commit das alterações e envie para o GitHub.
+2. Conecte o repositório na Vercel, utilizando o comando de build padrão (`npm run build`).
+3. Cadastre as variáveis de ambiente (`NEXT_PUBLIC_SUPABASE_URL`, `SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`, `GOOGLE_GENAI_API_KEY`).
+4. Realize o primeiro deploy e teste os fluxos de criação de projeto e submissão a partir do link gerado.
+
+Consulte a seção de instruções adicionais no final da resposta do agente para um passo a passo detalhado de configuração do Supabase e Vercel.

--- a/docs/supabase-schema.sql
+++ b/docs/supabase-schema.sql
@@ -1,0 +1,64 @@
+-- Habilite as extensões necessárias para geração de UUID e carimbo de data/hora
+create extension if not exists "pgcrypto";
+
+-- Função auxiliar para manter a coluna updated_at sincronizada
+create or replace function public.set_current_timestamp()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = timezone('utc', now());
+  return new;
+end;
+$$;
+
+create table if not exists public.projects (
+  id uuid primary key default gen_random_uuid(),
+  project_name text not null,
+  client_name text not null,
+  status text not null check (status in ('draft', 'in-progress', 'completed')),
+  notification_message text,
+  notification_is_comprehensive boolean,
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now())
+);
+
+create trigger set_timestamp_projects
+before update on public.projects
+for each row
+execute procedure public.set_current_timestamp();
+
+create table if not exists public.recipients (
+  id uuid primary key default gen_random_uuid(),
+  project_id uuid not null references public.projects(id) on delete cascade,
+  name text not null,
+  position text not null,
+  email text not null,
+  questions jsonb not null default '[]'::jsonb,
+  status text not null check (status in ('pending', 'sent', 'completed')),
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now())
+);
+
+create index if not exists recipients_project_id_idx on public.recipients(project_id);
+
+create trigger set_timestamp_recipients
+before update on public.recipients
+for each row
+execute procedure public.set_current_timestamp();
+
+create table if not exists public.submissions (
+  id uuid primary key default gen_random_uuid(),
+  project_id uuid not null references public.projects(id) on delete cascade,
+  recipient_id uuid not null references public.recipients(id) on delete cascade,
+  answers jsonb not null default '[]'::jsonb,
+  submitted_at timestamptz not null default timezone('utc', now()),
+  constraint submissions_recipient_unique unique (recipient_id)
+);
+
+create index if not exists submissions_project_id_idx on public.submissions(project_id);
+
+create trigger set_timestamp_submissions
+before update on public.submissions
+for each row
+execute procedure public.set_current_timestamp();

--- a/src/components/app/recipient-view.tsx
+++ b/src/components/app/recipient-view.tsx
@@ -19,9 +19,10 @@ interface RecipientViewProps {
   activeRecipientId: string | null;
   setActiveRecipientId: (id: string) => void;
   isRecipientSession?: boolean;
+  onProjectUpdated?: (project: Project) => void;
 }
 
-export default function RecipientView({ project, activeRecipientId, setActiveRecipientId, isRecipientSession }: RecipientViewProps) {
+export default function RecipientView({ project, activeRecipientId, setActiveRecipientId, isRecipientSession, onProjectUpdated }: RecipientViewProps) {
   const { toast } = useToast();
   const [isPending, startTransition] = useTransition();
   const [answers, setAnswers] = useState<Record<string, Answer>>({});
@@ -79,7 +80,10 @@ export default function RecipientView({ project, activeRecipientId, setActiveRec
       };
 
       try {
-        await submitResponse(submission);
+        const result = await submitResponse(submission);
+        if (result?.project && onProjectUpdated) {
+          onProjectUpdated(result.project);
+        }
         if (!isRecipientSession) {
             localStorage.removeItem(`submission_${project.id}_${activeRecipientId}`);
         }
@@ -120,7 +124,7 @@ export default function RecipientView({ project, activeRecipientId, setActiveRec
         <div className="flex justify-center">
             <div className="w-full max-w-sm">
                 <Label>Pré-visualizar como:</Label>
-                <Select value={activeRecipientId} onValueChange={setActiveRecipientId}>
+                <Select value={activeRecipientId ?? undefined} onValueChange={setActiveRecipientId}>
                     <SelectTrigger><SelectValue placeholder="Selecione um destinatário..." /></SelectTrigger>
                     <SelectContent>
                     {project.recipients.map(r => (

--- a/src/lib/supabase/client.ts
+++ b/src/lib/supabase/client.ts
@@ -1,0 +1,88 @@
+import 'server-only';
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!SUPABASE_URL) {
+  throw new Error('A variável de ambiente NEXT_PUBLIC_SUPABASE_URL não foi definida.');
+}
+
+if (!SUPABASE_SERVICE_ROLE_KEY) {
+  throw new Error('A variável de ambiente SUPABASE_SERVICE_ROLE_KEY não foi definida.');
+}
+
+const baseUrl = `${SUPABASE_URL.replace(/\/$/, '')}/rest/v1`;
+
+type HttpMethod = 'GET' | 'POST' | 'PATCH' | 'DELETE';
+
+interface SupabaseRequestOptions {
+  method?: HttpMethod;
+  searchParams?: Record<string, string>;
+  body?: unknown;
+  prefer?: string[];
+}
+
+function buildHeaders(hasBody: boolean, prefer?: string[]) {
+  const serviceRoleKey = SUPABASE_SERVICE_ROLE_KEY!;
+  const headers: Record<string, string> = {
+    apikey: serviceRoleKey,
+    Authorization: `Bearer ${serviceRoleKey}`,
+  };
+
+  if (prefer && prefer.length > 0) {
+    headers.Prefer = prefer.join(',');
+  }
+
+  if (hasBody) {
+    headers['Content-Type'] = 'application/json';
+  }
+
+  return headers;
+}
+
+export async function supabaseRequest<T>(path: string, options: SupabaseRequestOptions = {}): Promise<T> {
+  const { method = 'GET', searchParams, body, prefer } = options;
+  const url = new URL(`${baseUrl}/${path}`);
+
+  if (searchParams) {
+    for (const [key, value] of Object.entries(searchParams)) {
+      url.searchParams.set(key, value);
+    }
+  }
+
+  const response = await fetch(url.toString(), {
+    method,
+    headers: buildHeaders(body !== undefined, prefer),
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+    cache: 'no-store',
+  });
+
+  if (!response.ok) {
+    let message = `${response.status} ${response.statusText}`;
+
+    try {
+      const error = await response.json();
+      if (error?.message) {
+        message = error.message;
+      }
+    } catch {
+      const text = await response.text();
+      if (text) {
+        message = text;
+      }
+    }
+
+    throw new Error(message);
+  }
+
+  if (response.status === 204) {
+    return null as T;
+  }
+
+  const contentType = response.headers.get('content-type') ?? '';
+  if (!contentType.includes('application/json')) {
+    return null as T;
+  }
+
+  return (await response.json()) as T;
+}

--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -1,0 +1,32 @@
+import type { Answer } from '@/lib/types';
+
+export interface SupabaseProjectRow {
+  id: string;
+  project_name: string;
+  client_name: string;
+  status: 'draft' | 'in-progress' | 'completed';
+  notification_message: string | null;
+  notification_is_comprehensive: boolean | null;
+  created_at: string;
+  updated_at: string | null;
+}
+
+export interface SupabaseRecipientRow {
+  id: string;
+  project_id: string;
+  name: string;
+  position: string;
+  email: string;
+  questions: string[] | null;
+  status: 'pending' | 'sent' | 'completed';
+  created_at: string;
+  updated_at: string | null;
+}
+
+export interface SupabaseSubmissionRow {
+  id: string;
+  project_id: string;
+  recipient_id: string;
+  answers: Answer[] | null;
+  submitted_at: string;
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -35,4 +35,5 @@ export interface Submission {
   projectId: string;
   recipientId: string;
   answers: Answer[];
+  submittedAt?: string;
 }


### PR DESCRIPTION
## Summary
- replace the in-memory mock with Supabase-backed server actions and helper utilities
- load projects for recipient links, propagate updates to the UI, and expose a Supabase schema script
- document environment variables, add an ESLint preset, and share a sample env file

## Testing
- NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co SUPABASE_SERVICE_ROLE_KEY=service-key GOOGLE_GENAI_API_KEY=dummy npm run typecheck
- NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co SUPABASE_SERVICE_ROLE_KEY=service-key GOOGLE_GENAI_API_KEY=dummy npm run build


------
https://chatgpt.com/codex/tasks/task_e_68c88ecec298832791b2ec7fc80cda3b