### PR TITLE
feat: centralize core types and localize statuses

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,7 +4,7 @@ import React, { useEffect, useState } from "react";
 import { useSearchParams } from 'next/navigation';
 import AdminView from "@/components/app/admin-view";
 import RecipientView from "@/components/app/recipient-view";
-import type { Project } from "@/lib/types";
+import type { Project } from "@/types";
 import { AppHeader } from "@/components/app/header";
 
 export type ViewMode = "admin" | "recipient";

--- a/src/components/app/header.tsx
+++ b/src/components/app/header.tsx
@@ -5,7 +5,7 @@ import { Button } from "@/components/ui/button";
 import { ShieldCheck, User, Bell, CheckCircle, AlertTriangle } from "lucide-react";
 import type { ViewMode } from "@/app/page";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
-import type { Project } from "@/lib/types";
+import type { Project } from "@/types";
 import { Badge } from "@/components/ui/badge";
 
 interface AppHeaderProps {
@@ -17,7 +17,7 @@ interface AppHeaderProps {
 }
 
 export function AppHeader({ view, onViewChange, projectStatus, notification, isRecipientSession }: AppHeaderProps) {
-  const showNotification = projectStatus === 'completed' && notification;
+  const showNotification = projectStatus === 'concluido' && notification;
 
   return (
     <header className="sticky top-0 z-40 w-full border-b bg-card shadow-sm">

--- a/src/components/app/recipient-view.tsx
+++ b/src/components/app/recipient-view.tsx
@@ -7,7 +7,8 @@ import { Textarea } from "@/components/ui/textarea";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import type { Project, Answer, Submission } from '@/lib/types';
+import type { Project, Submission } from '@/types';
+import type { Answer } from '@/lib/types';
 import { QUESTIONS } from '@/lib/questions';
 import { submitResponse } from '@/lib/actions';
 import { useToast } from "@/hooks/use-toast";
@@ -46,7 +47,7 @@ export default function RecipientView({ project, activeRecipientId, setActiveRec
       setAnswers({});
     }
 
-    setIsSubmitted(activeRecipient?.status === 'completed');
+    setIsSubmitted(activeRecipient?.status === 'concluido');
   }, [activeRecipientId, project.id, activeRecipient?.status, isRecipientSession]);
 
   useEffect(() => {
@@ -120,7 +121,7 @@ export default function RecipientView({ project, activeRecipientId, setActiveRec
         <div className="flex justify-center">
             <div className="w-full max-w-sm">
                 <Label>Pré-visualizar como:</Label>
-                <Select value={activeRecipientId} onValueChange={setActiveRecipientId}>
+                <Select value={activeRecipientId ?? undefined} onValueChange={setActiveRecipientId}>
                     <SelectTrigger><SelectValue placeholder="Selecione um destinatário..." /></SelectTrigger>
                     <SelectContent>
                     {project.recipients.map(r => (

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -9,7 +9,7 @@ export const projectSchema = z.object({
     position: z.string().min(2, 'O cargo é obrigatório.'),
     email: z.string().email('O e-mail é inválido.'),
     questions: z.array(z.string()).optional(),
-    status: z.enum(['pending', 'sent', 'completed']).optional(),
+    status: z.enum(['pendente', 'enviado', 'concluido']).optional(),
   })).min(1, 'Adicione pelo menos um destinatário.'),
 });
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,38 +1,13 @@
+import type { JsonObject } from '@/types';
+
 export interface Question {
   id: string;
   text: string;
   category: string;
 }
 
-export interface Recipient {
-  id: string;
-  name: string;
-  position: string;
-  email: string;
-  questions: string[]; // Array of question IDs
-  status: 'pending' | 'sent' | 'completed';
-}
-
-export interface Project {
-  id: string;
-  projectName: string;
-  clientName: string;
-  recipients: Recipient[];
-  status: 'draft' | 'in-progress' | 'completed';
-  notification?: {
-    message: string;
-    isComprehensive: boolean;
-  };
-}
-
-export interface Answer {
+export interface Answer extends JsonObject {
   questionId: string;
-  textAnswer?: string;
-  fileAnswer?: string; // a path or URL to the uploaded file
-}
-
-export interface Submission {
-  projectId: string;
-  recipientId: string;
-  answers: Answer[];
+  textAnswer?: string | null;
+  fileAnswer?: string | null; // a path ou URL para o arquivo enviado
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,42 @@
+export type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue | undefined };
+
+export type JsonObject = { [key: string]: JsonValue | undefined };
+
+export type JsonArray = JsonValue[];
+
+export type RecipientStatus = 'pendente' | 'enviado' | 'concluido';
+
+export type ProjectStatus = 'rascunho' | 'em_andamento' | 'concluido';
+
+export interface Recipient {
+  id: string;
+  name: string;
+  position: string;
+  email: string;
+  questions: JsonArray;
+  status: RecipientStatus;
+}
+
+export interface Project {
+  id: string;
+  projectName: string;
+  clientName: string;
+  recipients: Recipient[];
+  status: ProjectStatus;
+  notification?: {
+    message: string;
+    isComprehensive: boolean;
+  };
+}
+
+export interface Submission {
+  projectId: string;
+  recipientId: string;
+  answers: JsonArray;
+}


### PR DESCRIPTION
## Summary
- add `src/types.ts` to centralize the Project, Recipient, and Submission definitions with JSON fields and Portuguese status enums
- update server actions, form logic, and UI components to rely on the new types and convert question assignments from JSON arrays when needed
- align the validation schema and header notification logic with the localized status strings

## Testing
- npm run typecheck
- npm run lint *(blocked by interactive ESLint configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68c8a15604048327be761874a37f8bff