### PR TITLE
Add supabaseServer helper for SSR client

### DIFF
--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -44,6 +44,11 @@ export const createSSRClient = (cookieStore: ReturnType<typeof cookies>) => {
   });
 };
 
+export const supabaseServer = () => {
+  const cookieStore = cookies();
+  return createSSRClient(cookieStore);
+};
+
 // Cliente admin (service role) — use SOMENTE no backend (server actions, route handlers, jobs)
 export const supabaseAdmin = (): SupabaseClient /* <Database> */ => {
   const { url, serviceRoleKey } = getServiceConfig();


### PR DESCRIPTION
## Summary
- add a supabaseServer helper that retrieves the Next.js cookie store and returns an SSR Supabase client

## Testing
- npm run lint *(fails: `next` command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9486516648327a470ee0e37f446bf