### PR TITLE
Remove temporary Supabase Page component

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,24 +7,6 @@ import RecipientView from "@/components/app/recipient-view";
 import type { Project } from "@/types";
 import { AppHeader } from "@/components/app/header";
 
-import { createClient } from '@/utils/supabase/server'
-import { cookies } from 'next/headers'
-
-export default async function Page() {
-  const cookieStore = await cookies()
-  const supabase = createClient(cookieStore)
-
-  const { data: todos } = await supabase.from('todos').select()
-
-  return (
-    <ul>
-      {todos?.map((todo) => (
-        <li>{todo}</li>
-      ))}
-    </ul>
-  )
-}
-
 export type ViewMode = "admin" | "recipient";
 
 function HomePageContent() {


### PR DESCRIPTION
## Summary
- remove the temporary `Page` component that fetched todos from Supabase
- clean up the unused Supabase and cookies imports so the file only exports `Home`

## Testing
- `npm run lint` *(fails: next binary missing because dependencies are not installed in the environment)*
- `npm install` *(fails: 403 fetching @supabase/supabase-js from npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68c9486df2a08327a7bb175754003f1d