### PR TITLE
Make supabase server client async

### DIFF
--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -55,7 +55,7 @@ const normalizeAnswerArray = (value: unknown): Answer[] => {
 const toJsonArray = (value: unknown): JsonArray => normalizeAnswerArray(value) as JsonArray;
 
 export async function createOrUpdateProject(data: ProjectFormData, existingProjectId?: string): Promise<Project> {
-  const supabase = supabaseServer();
+  const supabase = await supabaseServer();
   const validatedData = projectSchema.parse(data);
   const allQuestionIds = QUESTIONS.map(q => q.id);
 
@@ -184,7 +184,7 @@ export async function createOrUpdateProject(data: ProjectFormData, existingProje
 }
 
 export async function updateProjectQuestions(projectId: string, recipientId: string, questions: string[]): Promise<Project> {
-  const supabase = supabaseServer();
+  const supabase = await supabaseServer();
   const sanitizedQuestions = sanitizeQuestions(questions);
 
   try {
@@ -212,7 +212,7 @@ export async function updateProjectQuestions(projectId: string, recipientId: str
 }
 
 export async function markSingleEmailAsSent(projectId: string, recipientId: string): Promise<Project> {
-  const supabase = supabaseServer();
+  const supabase = await supabaseServer();
 
   try {
     const recipient = await fetchRecipientById(projectId, recipientId);
@@ -266,7 +266,7 @@ export async function markSingleEmailAsSent(projectId: string, recipientId: stri
 }
 
 export async function submitResponse(submission: Submission) {
-  const supabase = supabaseServer();
+  const supabase = await supabaseServer();
 
   try {
     const { data: existingSubmission, error: fetchSubmissionError } = await supabase

--- a/src/lib/supabase/projects.ts
+++ b/src/lib/supabase/projects.ts
@@ -81,7 +81,7 @@ export const mapProjectRow = (row: ProjectRow): Project => ({
 });
 
 export async function fetchProjectWithRecipients(projectId: string): Promise<Project | null> {
-  const supabase = supabaseServer();
+  const supabase = await supabaseServer();
 
   const { data, error } = await supabase
     .from("projects")
@@ -103,7 +103,7 @@ export async function fetchProjectWithRecipients(projectId: string): Promise<Pro
 }
 
 export async function fetchRecipientsByProjectId(projectId: string): Promise<RecipientRow[]> {
-  const supabase = supabaseServer();
+  const supabase = await supabaseServer();
 
   const { data, error } = await supabase
     .from("recipients")
@@ -118,7 +118,7 @@ export async function fetchRecipientsByProjectId(projectId: string): Promise<Rec
 }
 
 export async function fetchRecipientById(projectId: string, recipientId: string): Promise<RecipientRow | null> {
-  const supabase = supabaseServer();
+  const supabase = await supabaseServer();
 
   const { data, error } = await supabase
     .from("recipients")
@@ -135,7 +135,7 @@ export async function fetchRecipientById(projectId: string, recipientId: string)
 }
 
 export async function fetchSubmissionsByProjectId(projectId: string): Promise<SubmissionRow[]> {
-  const supabase = supabaseServer();
+  const supabase = await supabaseServer();
 
   const { data, error } = await supabase
     .from("submissions")


### PR DESCRIPTION
## Summary
- make the Supabase SSR client accept ReadonlyRequestCookies and type its cookie setters
- update supabaseServer to be async and await Next cookies before constructing the client
- await the async supabaseServer helper throughout server actions and Supabase query utilities

## Testing
- npm run typecheck *(fails: missing npm modules due to restricted registry access)*

------
https://chatgpt.com/codex/tasks/task_e_68c94e8be2e4832795d6be16743ce9cb